### PR TITLE
Update ruby to include 2.3

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -23,15 +23,24 @@
 
 2.2.4: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
 2.2: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
-2: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
-latest: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2
 
 2.2.4-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 2.2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
-2-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
-onbuild: git://github.com/docker-library/ruby@5d04363db6f7ae316ef7056063f020557db828e1 2.2/onbuild
 
 2.2.4-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
 2.2-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
-2-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
-slim: git://github.com/docker-library/ruby@90b6b506a4b495cd337115d9a2b4ba6f80c72004 2.2/slim
+
+2.3.0: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3
+2.3: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3
+2: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3
+latest: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3
+
+2.3.0-onbuild: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/onbuild
+2.3-onbuild: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/onbuild
+2-onbuild: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/onbuild
+onbuild: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/onbuild
+
+2.3.0-slim: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/slim
+2.3-slim: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/slim
+2-slim: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/slim
+slim: git://github.com/docker-library/ruby@b8e8fe051b3c3c1973a8998679bbd47d6ab13f69 2.3/slim


### PR DESCRIPTION
This will also replace latest/onbuild/slim with ruby 2.3
